### PR TITLE
重构接口，添加查询电费

### DIFF
--- a/hust_login/_HustPass.py
+++ b/hust_login/_HustPass.py
@@ -1,6 +1,10 @@
-from .login import HustLogin
+from .login import HustLogin, CheckLoginStatu
 from .utility_bills import GetElectricityBill
-from .curriculum import GetOneDay
+from .curriculum import GetCurriculum
+
+class HustPass_NotLoged(BaseException):
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args)
 
 class HustPass:
     def __init__(self, Uid:str, Pwd:str, headers:dict=None) -> None:
@@ -15,10 +19,34 @@ class HustPass:
             return False
         return True
 
-    def QueryElectricityBills(self, QueryDates:list) -> dict:
-        r=self.Session.get('http://pass.hust.edu.cn/cas/login?service=http://sdhq.hust.edu.cn/ICBS/hust/cas/neusoftcas.aspx')
-        print(r.cookies)
+    def CheckLoged(self):
+        if not CheckLoginStatu(self.Session):
+            raise HustPass_NotLoged
+
+    def QueryElectricityBills(self, QueryDates:str|list[str]|tuple[str,str]) -> dict:
+        '''
+        PARAMETERS:\n
+        QueryDates  -- str  : in form of '2023-7-21' or '2023/7/21'\n
+                    -- list : a list, each item in the same form\n
+                    -- tuple: two str, including the start and the end\n
+        \n
+        RETURN:\n
+        {'RoomName': 'XXX', 'RemainPower': 'XXX', 'DayCost': [{'daycost': 'XXX', 'date': 'YYYY-MM-DD', 'money': 'XXX'}]}
+        '''
+        self.CheckLoged()
         return GetElectricityBill(self.Session, self.Uid, QueryDates)
     
-    def QueryCurriculum(self, day:str, week:str) -> list:
-        return GetOneDay(self.Session, day, week)
+    def QueryCurriculum(self, QueryData:str|list[str]|int|tuple[str,str]) -> list:
+        '''
+        PARAMETERS:\n
+        session -- should be already logged in\n
+        date    -- str  : the day you want, in form of YYYY-MM-DD\n
+                -- list : a list, each item in the same form as above\n
+                -- int  : the week after the semester started\n
+                -- tuple: two str, including the start and the end\n
+        \n
+        RETURN:\n
+        [{'date':'YYYY-MM-DD','data':[{'No':'1', 'ClassName': 'XXX', 'TeacherName': 'XXX'}}]}]
+        '''
+        self.CheckLoged()
+        return GetCurriculum(self.Session, QueryData)

--- a/hust_login/_HustPass.py
+++ b/hust_login/_HustPass.py
@@ -1,0 +1,24 @@
+from .login import HustLogin
+from .utility_bills import GetElectricityBill
+from .curriculum import GetOneDay
+
+class HustPass:
+    def __init__(self, Uid:str, Pwd:str, headers:dict=None) -> None:
+        self.Session = HustLogin(Uid, Pwd, headers)
+        self.Uid = Uid
+
+    def __enter__(self):
+        return self
+    
+    def __exit__(self, type, value, trace):
+        if type is not None:
+            return False
+        return True
+
+    def QueryElectricityBills(self, QueryDates:list) -> dict:
+        r=self.Session.get('http://pass.hust.edu.cn/cas/login?service=http://sdhq.hust.edu.cn/ICBS/hust/cas/neusoftcas.aspx')
+        print(r.cookies)
+        return GetElectricityBill(self.Session, self.Uid, QueryDates)
+    
+    def QueryCurriculum(self, day:str, week:str) -> list:
+        return GetOneDay(self.Session, day, week)

--- a/hust_login/__init__.py
+++ b/hust_login/__init__.py
@@ -1,2 +1,3 @@
-from .login import HustPass, CheckLoginStatu
+from .login import HustLogin, CheckLoginStatu
 from . import curriculum # 课表相关归属在此命名空间下
+from ._HustPass import HustPass

--- a/hust_login/curriculum.py
+++ b/hust_login/curriculum.py
@@ -3,43 +3,112 @@ import requests
 import json
 from .login import CheckLoginStatu
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
 
 def weeks_from(start_date, date):
-    start_date = datetime.strptime(start_date, '%Y-%m-%d')
+    if not isinstance(start_date, datetime):
+        start_date = datetime.strptime(start_date, '%Y-%m-%d')
     date = datetime.strptime(date, '%Y-%m-%d')
     delta = date - start_date
     return delta.days // 7 + 1
 
-def GetOneDay(session:requests.Session, date_query:str) -> list[dict]:
+def GetOneDay(session:requests.Session, _date_query:str) -> tuple[list[dict], dict]:
     '''
     PARAMETERS:\n
     session -- should be already logged in\n
-    date     -- the day you want, in form of YYYY-MM-DD\n
+    date    -- the day you want, in form of YYYY-MM-DD\n
     \n
     RETURN:\n
-    [{'No':'1', 'ClassName': 'XXX', 'TeacherName': 'XXX'}}]
+    [{'No':'1', 'ClassName': 'XXX', 'TeacherName': 'XXX'}}, ...], {'Date':'2023-01-01','InWeek':'星期一'}\n
+    OR [],{'Date':'2013-01-01'}
     '''
-    if not (isinstance(session, requests.Session) and isinstance(date_query, str)):
+    if not (isinstance(session, requests.Session) and isinstance(_date_query, str)):
         raise TypeError('HUSTPASS: CHECK YOUR session, day AND week INPUT TYPE')
     
     if not CheckLoginStatu(session):
         raise ConnectionRefusedError('HUSTPASS: YOU HAVENT LOGGED IN')
     
-    date_query = datetime.strptime(date_query, '%Y-%m-%d').date().isoformat() # 保证日期格式标准，即补充用户可能忘记添加的0
-    
-    resp_html = session.get('http://hub.m.hust.edu.cn/kcb/todate/datecourseNew.action')
+    date_query = datetime.strptime(_date_query, '%Y-%m-%d').date().isoformat() # 保证日期格式标准，即补充用户可能忘记添加的0
 
+    resp_html = session.get('http://hub.m.hust.edu.cn/kcb/todate/datecourseNew.action')
     start_date_semester = re.search(
         'var sDate = "(.*)";', resp_html.text).group(1) # 从html抓取学期开始日期
     
     week = weeks_from(start_date_semester, date_query)
+    return _GetOneDay(session, date_query, week)
     
+def _GetOneDay(session:requests.Session, date_query:str, week:int) -> tuple[list[dict], dict]:
     resp_api = session.get('http://hub.m.hust.edu.cn/kcb/todate/JsonCourse.action?sj={}&zc={}'.format(date_query, week))
     content=json.loads(resp_api.text)
     ret = []
+    info = {'Date':date_query} 
     for item in content:
         if item['kc'][0]['JSMC']=='—':
             continue
-        ret.append({'No':item['jcx'],'ClassName':item['kc'][0]['KCMC'],'TeacherName':item['kc'][0]['XM']})
+        ret.append({'No':item['jcx'],'ClassName':item['kc'][0]['KCMC'],'TeacherName':item['kc'][0]['XM'],'Place':item['kc'][0]['JSMC']})
+        info['InWeek']=item['kc'][0]['XQ']
+    return ret, info
+
+def GetCurriculum(session:requests.Session, _date_query:str|list[str]|int|tuple[str,str]) -> list:
+    '''
+    PARAMETERS:\n
+    session -- should be already logged in\n
+    date    -- str  : the day you want, in form of YYYY-MM-DD\n
+            -- list : a list, each item in the same form as above\n
+            -- int  : the week after the semester started\n
+            -- tuple: two str, including the start and the end\n
+    \n
+    RETURN:\n
+    [([{'No':'1', 'ClassName': 'XXX', 'TeacherName': 'XXX'}}, ...], {'Date':'2023-01-01','InWeek':'星期一'}), ...]\n
+    OR [],{'Date':'2013-01-01'}
+    '''
+    resp_html = session.get('http://hub.m.hust.edu.cn/kcb/todate/datecourseNew.action')
+    start_date_semester =datetime.strptime(re.search(
+        'var sDate = "(.*)";', resp_html.text).group(1), '%Y-%m-%d')  # 从html抓取学期开始日期
+    
+    query_list = []
+
+    if isinstance(_date_query, int):
+        _week = _date_query
+        start_date = start_date_semester + timedelta(weeks=_week)
+        for i in range(7):
+            query_list.append(((start_date+timedelta(days=i)).date().isoformat(), _week))
+
+    elif isinstance(_date_query, tuple):
+        if len(_date_query) !=2:
+            raise ValueError('HUSTPASS: ONLY ("YYYY-MM-DD","YYYY-MM-DD") LIKE TUPLE IS ACCEPTED')
+        _start_date, _end_date = _date_query
+        S_date = datetime.strptime(_start_date, '%Y-%m-%d')
+        E_date = datetime.strptime(_end_date, '%Y-%m-%d')
+        if S_date == E_date:
+            _time = S_date.date().isoformat()
+            query_list.append((_time, weeks_from(start_date_semester, _time)))
+        elif S_date < E_date:
+            S_date = datetime.strptime(_end_date, '%Y-%m-%d')
+            E_date = datetime.strptime(_start_date, '%Y-%m-%d')
+
+        if len(query_list)!=1:
+            for i in range((E_date-S_date).days+1):
+                C_date = (S_date + timedelta(days=1)).date().isoformat()
+                query_list.append((C_date, weeks_from(start_date_semester, C_date)))
+
+    elif isinstance(_date_query, list):
+        for _item in _date_query:
+            if not isinstance(_item, str):
+                raise ValueError('HUSTPASS:ONLY "YYYY-MM-DD" ITEM IS ACCEPTED')
+            else:
+                item = datetime.strptime(_item, '%Y-%m-%d').date().isoformat()
+                query_list.append((item, weeks_from(start_date_semester, item)))
+
+    elif isinstance(_date_query, str):
+        date_query = datetime.strptime(_date_query, '%Y-%m-%d').date().isoformat()
+        query_list.append((date_query, weeks_from(start_date_semester, date_query)))
+
+    else:
+        raise TypeError('HUSTPASS: UNSUPPORT TYPE')
+
+    ret = []
+    for pack in query_list:
+        date, week = pack
+        ret.append(_GetOneDay(session, date, week))
     return ret

--- a/hust_login/login.py
+++ b/hust_login/login.py
@@ -8,7 +8,7 @@ from base64 import b64encode, b64decode
 from .decaptcha import decaptcha
 
 
-def HustPass(username:str, password:str, headers:dict=None) -> requests.Session:# 以便ide进行类型检查与代码补全
+def HustLogin(username:str, password:str, headers:dict=None) -> requests.Session:# 以便ide进行类型检查与代码补全
     '''
     PARAMETERS:\n
     username -- Username of pass.hust.edu.cn  e.g. U2022XXXXX\n

--- a/hust_login/utility_bills.py
+++ b/hust_login/utility_bills.py
@@ -1,37 +1,78 @@
 import requests
 import re
 from .login import CheckLoginStatu
+from datetime import datetime
 
-def GetElectricityBill(session:requests.Session, Uid:str, QueryDates:list) -> dict:
+def DateLoad(_QueryDate:str) -> str:
+    if re.search('(\d*/\d*/\d*)', _QueryDate) is None :
+        if re.search('(\d*-\d*-\d*)', _QueryDate) is None:
+            raise
+        _date = datetime.strptime(_QueryDate, '%Y-%m-%d')
+    else:
+        _date = datetime.strptime(_QueryDate, '%Y/%m/%d')
+    return _date
+
+def DateFormat(_date:datetime):
+    date = _date.date().timetuple()
+    return str(date.tm_year)+'/'+str(date.tm_mon)+'/'+str(date.tm_mday)
+
+def GetElectricityBill(session:requests.Session, Uid:str, _QueryDate:str|list[str]|tuple[str,str]) -> dict:
+    '''
+    PARAMETERS:\n
+    session     -- should be already logged in\n
+    Uid         -- str  : your student uid\n
+    QueryDates  -- str  : in form of '2023-7-21' or '2023/7/21'\n
+                -- list : a list, each item in the same form\n
+                -- tuple: two str, including the start and the end\n
+    \n
+    RETURN:\n
+    {'RoomName': 'XXX', 'RemainPower': 'XXX', 'DayCost': [{'daycost': 'XXX', 'date': 'YYYY-MM-DD', 'money': 'XXX'}]}
+    '''
+    session.get('http://pass.hust.edu.cn/cas/login?service=http://sdhq.hust.edu.cn/icbs/hust/cas/neusoftcas.aspx')
+    Query_list = []
+    if isinstance(_QueryDate, list):
+        for _item in _QueryDate:
+            Query_list.append(DateFormat(DateLoad(_item)))
+
+    elif isinstance(_QueryDate, tuple):
+        if len(_QueryDate) !=2:
+            raise ValueError('HUSTPASS: ONLY ("XXX","XXX") LIKE TUPLE IS ACCEPTED')
+        _start_date, _end_date = _QueryDate
+        S_date = DateLoad(_start_date)
+        E_date = DateLoad(_end_date)
+        if S_date == E_date:
+            Query_list.append(DateFormat(S_date))
+        elif S_date > E_date:
+            S_date = DateLoad(_end_date)
+            E_date = DateLoad(_start_date)
+
+        if len(Query_list)!=1:
+            Query_list = (DateFormat(S_date),DateFormat(E_date))
+
+    elif isinstance(_QueryDate, str):
+        Query_list.append(DateFormat(DateLoad(_QueryDate)))
+
+    else:
+        raise TypeError('HUSTPASS: UNSUPPORT TYPE')
+
     if not CheckLoginStatu(session):
         raise ConnectionRefusedError('HUSTPASS: YOU HAVENT LOGGED IN')
-    try:
-        _startDate = QueryDates[0]
-        _endDate = QueryDates[1]
-    except:
-        raise
-    if re.search('(\d*/\d*/\d*)', _startDate) is None or re.search('(\d*/\d*/\d*)', _endDate) is None:
-        raise
 
-    #jar = requests.cookies.RequestsCookieJar()
-    #for cookie in cookies.split(";"):
-    #    key, value = cookie.split("=", 1)
-    #    jar.set(key, value)
-
-    resp0 = session.get('http://sdhq.hust.edu.cn/icbs/PurchaseWebService.asmx/getRoomInfobyStudentID?Student_ID={}'.format(Uid))
-    payload0 = resp0.text
+    payload0 = session.get(
+        'http://sdhq.hust.edu.cn/icbs/PurchaseWebService.asmx/getRoomInfobyStudentID?Student_ID={}'.format(Uid)).text
     if re.search('<msg>成功</msg>', payload0) is None:
-        print(resp0)
         raise
-    _RNo = re.search('<RoomNo>(.*</RoomNo>', payload0).group(1)
+    _RNo = re.search('<RoomNo>(.*)</RoomNo>', payload0).group(1)
     ret_Name = re.search('<RoomName>(.*)</RoomName>', payload0).group(1)
 
-    payload1 = session.get('http://sdhq.hust.edu.cn/icbs/PurchaseWebService.asmx/getMeterInfo?Room_ID={}'.format(_RNo)).text
+    payload1 = session.get(
+        'http://sdhq.hust.edu.cn/icbs/PurchaseWebService.asmx/getMeterInfo?Room_ID={}'.format(_RNo)).text
     if re.search('<msg>成功</msg>', payload1) is None:
         raise
     MeterID = re.search('<meterId>(.*)</meterId>', payload1).group(1)
 
-    payload2 = session.get('http://sdhq.hust.edu.cn/icbs/PurchaseWebService.asmx/getReserveHKAM?AmMeter_ID={}'.format(MeterID)).text
+    payload2 = session.get(
+        'http://sdhq.hust.edu.cn/icbs/PurchaseWebService.asmx/getReserveHKAM?AmMeter_ID={}'.format(MeterID)).text
     if re.search('<msg>成功</msg>', payload2) is None:
         raise
     _remainPower = re.search('<remainPower>(.*)</remainPower>', payload2).group(1)
@@ -39,7 +80,18 @@ def GetElectricityBill(session:requests.Session, Uid:str, QueryDates:list) -> di
     price_per_unit = re.search('<basePrice>(.*)</basePrice>',payload2).group(1)
     ret_remainPower = _remainPower+_unit
     
-    payload3 = session.get('http://sdhq.hust.edu.cn/icbs/PurchaseWebService.asmx/getMeterDayValue?AmMeter_ID={}&startDate=2023/7/21&endDate=2023/7/21'.format(MeterID)).text
+    ret = []
+    if isinstance(Query_list, list):
+        for item in Query_list:
+            ret.append(_GetOneDay(session, MeterID, item, item)[0])
+    elif isinstance(Query_list, tuple):
+        ret = _GetOneDay(session, MeterID, Query_list[0], Query_list[1])
+
+    return {'RoomName':ret_Name, 'RemainPower':ret_remainPower, 'DayCosts':ret}
+
+def _GetOneDay(session:requests.Session, MeterID:str, S_Date:str, E_Date:str) -> list[dict]:
+    payload3 = session.get(
+        'http://sdhq.hust.edu.cn/icbs/PurchaseWebService.asmx/getMeterDayValue?AmMeter_ID={}&startDate={}&endDate={}'.format(MeterID, S_Date, E_Date)).text
     if re.search('<msg>成功</msg>', payload3) is None:
         raise
     ret_daycost = []
@@ -50,5 +102,4 @@ def GetElectricityBill(session:requests.Session, Uid:str, QueryDates:list) -> di
         money = re.search('<dayUseMeony>(.*)</dayUseMeony>',item).group(1)
         date = re.search('<curDayTime>(.*)</curDayTime>', item).group(1)
         ret_daycost.append({'daycost':elc_cost+cost_unit,'date':date,'money':money})
-    
-    return {'RoomName':ret_Name, 'RemainPower':ret_remainPower, 'DayCost':ret_daycost}
+    return ret_daycost

--- a/hust_login/utility_bills.py
+++ b/hust_login/utility_bills.py
@@ -1,0 +1,54 @@
+import requests
+import re
+from .login import CheckLoginStatu
+
+def GetElectricityBill(session:requests.Session, Uid:str, QueryDates:list) -> dict:
+    if not CheckLoginStatu(session):
+        raise ConnectionRefusedError('HUSTPASS: YOU HAVENT LOGGED IN')
+    try:
+        _startDate = QueryDates[0]
+        _endDate = QueryDates[1]
+    except:
+        raise
+    if re.search('(\d*/\d*/\d*)', _startDate) is None or re.search('(\d*/\d*/\d*)', _endDate) is None:
+        raise
+
+    #jar = requests.cookies.RequestsCookieJar()
+    #for cookie in cookies.split(";"):
+    #    key, value = cookie.split("=", 1)
+    #    jar.set(key, value)
+
+    resp0 = session.get('http://sdhq.hust.edu.cn/icbs/PurchaseWebService.asmx/getRoomInfobyStudentID?Student_ID={}'.format(Uid))
+    payload0 = resp0.text
+    if re.search('<msg>成功</msg>', payload0) is None:
+        print(resp0)
+        raise
+    _RNo = re.search('<RoomNo>(.*</RoomNo>', payload0).group(1)
+    ret_Name = re.search('<RoomName>(.*)</RoomName>', payload0).group(1)
+
+    payload1 = session.get('http://sdhq.hust.edu.cn/icbs/PurchaseWebService.asmx/getMeterInfo?Room_ID={}'.format(_RNo)).text
+    if re.search('<msg>成功</msg>', payload1) is None:
+        raise
+    MeterID = re.search('<meterId>(.*)</meterId>', payload1).group(1)
+
+    payload2 = session.get('http://sdhq.hust.edu.cn/icbs/PurchaseWebService.asmx/getReserveHKAM?AmMeter_ID={}'.format(MeterID)).text
+    if re.search('<msg>成功</msg>', payload2) is None:
+        raise
+    _remainPower = re.search('<remainPower>(.*)</remainPower>', payload2).group(1)
+    _unit = re.search('<remainName>(.*)</remainName>', payload2).group(1)
+    price_per_unit = re.search('<basePrice>(.*)</basePrice>',payload2).group(1)
+    ret_remainPower = _remainPower+_unit
+    
+    payload3 = session.get('http://sdhq.hust.edu.cn/icbs/PurchaseWebService.asmx/getMeterDayValue?AmMeter_ID={}&startDate=2023/7/21&endDate=2023/7/21'.format(MeterID)).text
+    if re.search('<msg>成功</msg>', payload3) is None:
+        raise
+    ret_daycost = []
+    for _item in re.finditer('<DayValueInfo>(.*)</DayValueInfo>', payload3, re.S):
+        item = _item.group(1)
+        elc_cost = re.search('<dayValue>(.*)</dayValue>', item).group(1)
+        cost_unit = re.search('<dw>(.*)</dw>', item).group(1)
+        money = re.search('<dayUseMeony>(.*)</dayUseMeony>',item).group(1)
+        date = re.search('<curDayTime>(.*)</curDayTime>', item).group(1)
+        ret_daycost.append({'daycost':elc_cost+cost_unit,'date':date,'money':money})
+    
+    return {'RoomName':ret_Name, 'RemainPower':ret_remainPower, 'DayCost':ret_daycost}

--- a/test_basic.py
+++ b/test_basic.py
@@ -7,4 +7,4 @@ Uname = input('Uid:')
 Upass = input('Pwd:')
 
 with HustPass(Uname, Upass) as s:
-    print(curriculum.GetOneDay(s, '2023-03-28'))
+    print(s.QueryElectricityBills(['2023/7/21','2023/7/21']))

--- a/test_basic.py
+++ b/test_basic.py
@@ -1,4 +1,4 @@
-from hust_login import HustPass, curriculum
+from hust_login import HustPass
 import logging
 logging.basicConfig(level=logging.DEBUG,\
                     format='[%(levelname)s]  %(message)s')
@@ -7,4 +7,4 @@ Uname = input('Uid:')
 Upass = input('Pwd:')
 
 with HustPass(Uname, Upass) as s:
-    print(s.QueryElectricityBills(['2023/7/21','2023/7/21']))
+    print(s.QueryElectricityBills(('2023-4-1', '2023-4-12')))


### PR DESCRIPTION
将原本的HustPass函数改回HustLogin，并构建新的HustPass类，包含一些常用查询函数（目前只有查询课表与电费）

将课表查询的接口重构了，现在它支持更多的输入

添加了查询用电的接口，如查询课表一样支持、多种输入。目前查询一段时间的电费接口似乎有问题，需要修改（具体函数在utility_bills.py/_GetOneDay）

注：电费查询需要先登陆到sdhq.hust.edu.cn（即一个不处理返回值的get），否则无权限访问后续接口

不太确定各个接口的批注是否通俗易懂，你可以也看看，做些修改