### PR TITLE
Introducing cli script support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            artifact/hust_login-*.whl
+            artifact/*
 
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest] #[windows-latest, macos-latest, ubuntu-latest]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -23,7 +19,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          echo ${{ github.ref }} == 'refs/tags/'
           python -m pip install --upgrade pip
           pip install --upgrade setuptools
           pip install build
@@ -100,6 +95,7 @@ jobs:
             artifact/*
 
       - name: Publish package
+        if: ! endsWith(github.ref, 'dev')
         uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
         with:
           user: __token__

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          echo ${{ github.ref }}
           python -m pip install --upgrade pip
           pip install --upgrade setuptools
           pip install build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest] #[windows-latest, macos-latest, ubuntu-latest]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -100,6 +96,7 @@ jobs:
             artifact/*
 
       - name: Publish package
+        if: ! startsWith(github.ref, '/refs/tags/dev')
         uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
         with:
           user: __token__

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,6 @@ jobs:
       contents: write
 
     steps:
-      - name: Check if push is tag
-        run: 
-          echo "Push is a tag"
-
       - name: Download artifacts
         uses: actions/download-artifact@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          echo ${{ github.ref }}
+          echo ${{ github.ref }} == 'refs/tags/'
           python -m pip install --upgrade pip
           pip install --upgrade setuptools
           pip install build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
             artifact/*
 
       - name: Publish package
-        if: ! endsWith(github.ref, 'dev')
+        if: (! endsWith(github.ref, 'dev'))
         uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
         with:
           user: __token__

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest] #[windows-latest, macos-latest, ubuntu-latest]
 
     steps:
       - name: Checkout code
@@ -96,7 +100,6 @@ jobs:
             artifact/*
 
       - name: Publish package
-        if: ! startsWith(github.ref, '/refs/tags/dev')
         uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
         with:
           user: __token__

--- a/hust_login/_HustPass.py
+++ b/hust_login/_HustPass.py
@@ -1,7 +1,7 @@
 from .login import HustLogin, CheckLoginStatu
 from .utility_bills import GetElectricityBill
-from .curriculum import GetCurriculum
-from .free_room import GetFreeRoom
+from .curriculum import QuerySchedules
+from .free_room import GetFreeRooms
 from .ecard_bills import GetEcardBills
 
 class HustPass_NotLoged(BaseException):
@@ -44,7 +44,7 @@ class HustPass:
         self.CheckLoged()
         return GetElectricityBill(self.Session, self.Uid, QueryDates)
     
-    def QueryCurriculum(self, QueryData:str|list[str]|int|tuple[str,str]) -> list:
+    def QuerySchedules(self, QueryData:str|list[str]|int|tuple[str,str]) -> list:
         '''
         PARAMETERS:\n
         session -- should be already logged in\n
@@ -57,9 +57,9 @@ class HustPass:
         [{'Date':'YYYY-MM-DD','Curriculum':[{'No':'1', 'ClassName': 'XXX', 'TeacherName': 'XXX'}]}]
         '''
         self.CheckLoged()
-        return GetCurriculum(self.Session, QueryData)
+        return QuerySchedules(self.Session, QueryData)
     
-    def QueryFreeRoom(self, QueryData:str) -> dict:
+    def QueryFreeRooms(self, QueryData:str) -> dict:
         '''
         PARAMETERS:\n
         session -- should be already logged in\n
@@ -69,7 +69,7 @@ class HustPass:
         {'Date':'YYYY-MM-DD','Buildings':['东九楼A':{'No':'1','Roomlist': ['A101','A102']}]}
         '''
         self.CheckLoged()
-        return GetFreeRoom(self.Session, QueryData)
+        return GetFreeRooms(self.Session, QueryData)
     
     def QueryEcardBills(self, QueryData:str|list[str]|tuple[str,str]) -> list:
         '''

--- a/hust_login/__main__.py
+++ b/hust_login/__main__.py
@@ -1,12 +1,17 @@
 import sys
-import getopt
+from getopt import getopt
+from . import HustPass
+import logging
+logging.basicConfig(level=logging.DEBUG,\
+                    format='[%(levelname)s]  %(message)s')
 
 def __show_usage(code:int=-1):
     print('''\nUSAGE: python -m hust_pass <option>
     -U              Username of pass.hust.edu.cn
     -P              Password of pass.hust.edu.cn
         --autotest  Automatically test api availability, need Uid and Pwd
-    -r              Read Uid and Pwd from file
+    -f              Read Uid, Pwd and Tasks from file
+    -o              Output Result to a file (Unconditional OVERWRITE)
     -v, --version   Version of hust-login
     -h, --help      Get help
     ''')
@@ -16,20 +21,50 @@ def __show_usage(code:int=-1):
 ''')
     elif code == -3:
         print('''
-    The file format should be like {"Uid": "XXX", "Pwd": "XXX"}
+    The input file format should be like {"Uid": "XXX", "Pwd": "XXX"}\n
+    Use \033[0;33;40mpython -m hust_login --inputformat\033[0m to get more info
     ''')
     return code
 
+def __tasker(hpass:HustPass, Dict:dict) -> dict:
+    ret = {'Uid':hpass.Uid}
+    for key,value in Dict.items():
+        if key == 'QueryElectricityBills':
+            ret['ElectricityBills'] = __get_result(value, hpass.QueryElectricityBills)
+        elif key == 'QuerySchedules':
+            ret['Schedules'] = __get_result(value, hpass.QuerySchedules)
+        elif key == 'QueryFreeRooms':
+            ret['FreeRooms'] = __get_result(value, hpass.QueryFreeRooms)
+        elif key == 'QueryEcardBills':
+            ret['EcardBills'] = __get_result(value, hpass.QueryEcardBills)
+        else:
+            continue
+    return ret
+
+def __get_result(Dict:dict, Func) -> dict:
+    ret = {}
+    for key, value in Dict.items():
+        if key == 'list':
+            ret[key] = Func(value)
+        elif key == 'str':
+            ret[key] = Func(value)
+        elif key == 'tuple':
+            ret[key] = Func((value[0],value[1]))
+        elif key == 'int':
+            ret[key] = Func(value)
+        else:
+            raise KeyError('UNEXPECTED PARAMETERS')
+    return ret
+
 def main():
     try:
-        opts, args = getopt.getopt(sys.argv[1:],'U:P:r:hv',['autotest','help','version'])
+        opts, args = getopt(sys.argv[1:],'U:P:f:o:hv',['autotest','help','version','inputformat'])
     except:
         return __show_usage()
 
     autotest = False
-
-    Uid = None
-    Pwd = None
+    fpath = None
+    opath = None
 
     for opt,arg in opts:
         if opt in ['-h', '--help']:
@@ -39,39 +74,64 @@ def main():
             return __version__
         elif opt == '--autotest':
             autotest = True
+        elif opt == '--inputformat':
+            with open('example.json','r') as fp:
+                print(fp.read())
+            return 0
         elif opt =='-U':
             Uid = arg
         elif opt == '-P':
             Pwd = arg
-        elif opt == '-r':
+        elif opt == '-f':
             fpath = arg
+        elif opt == '-o':
+            opath = arg
         else:
             return __show_usage()
-        
-    if Uid is None and Pwd is None:
-        try:
+    
+
+    header = None
+
+    if fpath is not None:
+        with open(fpath,'r') as fp:
             import json
-            with open(fpath,'r') as fp:
+            try:
                 conf = json.loads(fp.read())
+            except FileNotFoundError:
+                return __show_usage(-2)
+            except json.decoder.JSONDecodeError:
+                return __show_usage(-3)
+            try:
                 Uid = conf['Uid']
                 Pwd = conf['Pwd']
-        except FileNotFoundError:
-            return __show_usage(-2)
-        except json.decoder.JSONDecodeError:
-            return __show_usage(-3)
-    elif Uid is not None and Pwd is not None:
-        pass
-    else:
+            except KeyError:
+                return __show_usage(-3)
+            try:
+                header = conf['Headers']
+            except KeyError:
+                pass
+
+
+    try:
+        HUSTpass = HustPass(Uid, Pwd, header)
+    except NameError:
         return __show_usage()
-        
+    
     if autotest:
         from .autotest import full_test
-        try:
-            code = full_test(Uid,Pwd)
-        except:
+        code = full_test(HUSTpass)
+        if code != 0:
             print('Test Failed')
-            return -1
-        return code
+            return code
+        return 0
     
+    if opath is not None:
+        try:
+            with open(opath,'w') as fp:
+                fp.write(json.dumps(__tasker(HUSTpass, conf['Tasks'])))
+        except:
+            return -1
+    else:
+        print(__tasker(HUSTpass, conf['Tasks']))
 if __name__ == '__main__':
     main()

--- a/hust_login/__main__.py
+++ b/hust_login/__main__.py
@@ -116,6 +116,9 @@ def main():
         HUSTpass = HustPass(Uid, Pwd, header)
     except NameError:
         return __show_usage()
+    except ConnectionRefusedError:
+        print('HUSTPASS: Authentication failed')
+        return -1
     
     if autotest:
         from .autotest import full_test

--- a/hust_login/autotest.py
+++ b/hust_login/autotest.py
@@ -19,4 +19,8 @@ def full_test(Uid,Pwd):
         hpass.QueryFreeRoom('2023-09-02')
     except:
         return 30
+    try:
+        hpass.QueryEcardBills('2023-09-02')
+    except:
+        return 40
     return 0

--- a/hust_login/autotest.py
+++ b/hust_login/autotest.py
@@ -1,7 +1,4 @@
-from . import HustPass
-
-def full_test(Uid,Pwd):
-    hpass = HustPass(Uid, Pwd)
+def full_test(hpass):
     try:
         hpass.QueryCurriculum('2023-04-27')
         hpass.QueryCurriculum(['2023-04-27','2023-03-27','2023-04-07'])

--- a/hust_login/curriculum.py
+++ b/hust_login/curriculum.py
@@ -63,7 +63,7 @@ def _GetOneDay(session:requests.Session, date_query:str, week:int) -> tuple[list
     ret['curriculum'] = class_list
     return ret
 
-def GetCurriculum(session:requests.Session, _date_query:str|list[str]|int|tuple[str,str]) -> list:
+def QuerySchedules(session:requests.Session, _date_query:str|list[str]|int|tuple[str,str]) -> list:
     '''
     PARAMETERS:\n
     session -- should be already logged in\n

--- a/hust_login/ecard_bills.py
+++ b/hust_login/ecard_bills.py
@@ -78,7 +78,6 @@ def _GetMonth(session:requests.Session, account:str, _QueryMonth:str) -> list:
         current_page = next_page_obt
         url = '{}?account={}&curpage={}&dateStatus={}&typeStatus=2'.format(url_base,account,current_page,_QueryMonth)    
         resp = session.get(url).text
-        print(resp.strip().strip('callJson(').strip(')'))
         raw = json.loads(resp.strip().strip('callJson(').strip(')'))
         next_page_obt = str(raw['nextpage'])
         entrys = raw['consume']
@@ -112,7 +111,7 @@ def GetEcardBills(session:requests.Session, _QueryDate:str|list[str]|tuple[str,s
     {'RoomName': 'XXX', 'RemainPower': 'XXX', 'DayCost': [{'daycost': 'XXX', 'date': 'YYYY-MM-DD', 'money': 'XXX'}]}
     '''
     if not CheckLoginStatu(session):
-        raise ConnectionRefusedError('HUSTPASS: YOU HAVENT LOGGED IN')
+        raise ConnectionRefusedError('HUSTPASS: YOU HAVEN`T LOGGED IN')
     
     # 抓取校园卡账户
     resp = session.get('http://ecard.m.hust.edu.cn/wechat-web/QueryController/Queryurl.html')

--- a/hust_login/example.json
+++ b/hust_login/example.json
@@ -1,0 +1,26 @@
+{
+    "Uid":"SOME STR",
+    "Pwd":"SOME STR",
+    "Headers":"OPITONAL",
+    "Tasks":{
+        "QueryElectricityBills":{
+            "str":"ONE DAY",
+            "list":["ONE DAY","ANOTHER DAY","ADD MORE OR NOT"],
+            "tuple":["ONE DAY","ONLY TWO VALVE"]
+        },
+        "QuerySchedules":{
+            "str":"ONE DAY",
+            "list":["ONE DAY","ANOTHER DAY","ADD MORE OR NOT"],
+            "tuple":["ONE DAY","ONLY TWO VALVE"],
+            "int": 0
+        },
+        "QueryFreeRooms":{
+            "str":"ONE DAY"
+        },
+        "QueryEcardBills":{
+            "str":"ONE DAY",
+            "list":["ONE DAY","ANOTHER DAY","ADD MORE OR NOT"],
+            "tuple":["ONE DAY","ONLY TWO VALVE"]
+        }
+    }
+}

--- a/hust_login/free_room.py
+++ b/hust_login/free_room.py
@@ -1,10 +1,8 @@
 import requests
 import json
-# from .login import CheckLoginStatu
-import re
-from datetime import datetime, timedelta
+from datetime import datetime
 
-def GetFreeRoom(session:requests.Session, _date_query:str) -> dict:
+def GetFreeRooms(session:requests.Session, _date_query:str) -> dict:
     '''
     PARAMETERS:\n
     session -- should be already logged in\n

--- a/hust_login/login.py
+++ b/hust_login/login.py
@@ -80,7 +80,7 @@ def HustLogin(username:str, password:str, headers:dict=None) -> requests.Session
     try:
         resp.headers['Location']
     except:
-        raise Exception("---HustPass Failed---")
+        raise ConnectionRefusedError("---HustPass Failed---")
     log.info("---HustPass Succeed---")
     log.debug('Thank you for using hust_login')
     return r

--- a/test.json
+++ b/test.json
@@ -1,0 +1,18 @@
+{
+    "Uid":"",
+    "Pwd":"",
+    "Tasks":{
+        "QueryElectricityBills":{
+            "tuple":["2023-04-03","2023-04-10"]
+        },
+        "QuerySchedules":{
+            "int": 8
+        },
+        "QueryFreeRooms":{
+            "str":"2023-04-03"
+        },
+        "QueryEcardBills":{
+            "str":"2023-04-03"
+        }
+    }
+}

--- a/test_basic.py
+++ b/test_basic.py
@@ -14,11 +14,11 @@ with open('secret.txt', 'r') as f:
 
 with HustPass(Uname, Upass) as s:
     with open('curriculum.json','w', encoding='utf-8') as f:
-        f.write(json.dumps(s.QueryCurriculum(('2023-04-03','2023-04-10')), ensure_ascii=False))
+        f.write(json.dumps(s.QuerySchedules(('2023-04-03','2023-04-10')), ensure_ascii=False))
     with open('ecard_bill.json','w', encoding='utf-8') as f:
         f.write(json.dumps(s.QueryEcardBills('2023-04'), ensure_ascii=False))
     with open('free_room.json','w', encoding='utf-8') as f:
-        f.write(json.dumps(s.QueryFreeRoom('2023-04-03'), ensure_ascii=False))
+        f.write(json.dumps(s.QueryFreeRooms('2023-04-03'), ensure_ascii=False))
     with open('electricity_bill.json','w', encoding='utf-8') as f:
         f.write(json.dumps(s.QueryElectricityBills(('2023-04-03','2023-04-10')), ensure_ascii=False))
         


### PR DESCRIPTION
Now you can use `python -m hust_login -f test.json` to get the result rather writing a .py file to execute these.
All existing input types are supported. 
The results are in form of  `{"Uid":"XXX","ElectricityBills":{},"Schedules":{},"FreeRooms":{},"EcardBills":{}}`. You can use `-o result.json` to save them to a file.

I also changed the CI and now `v1.0.0-dev` or `v1.0.0_dev` will not be published to PyPI.