### PR TITLE
make autotest really work

### DIFF
--- a/.github/workflows/auto-test.yml
+++ b/.github/workflows/auto-test.yml
@@ -45,5 +45,5 @@ jobs:
       
       - name: Test module
         run: |
-          python -m hust_login --autotest -U ${{ secrets.Uid }} -P ${{ secrets.Pwd }}
+          python -m hust_login --autotest -U ${{ secrets.UID }} -P ${{ secrets.PWD }}
           

--- a/.github/workflows/auto-test.yml
+++ b/.github/workflows/auto-test.yml
@@ -24,7 +24,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install hust_login
 
-      - name: Install MacPorts
+      - name: Install MacPorts(Mac)
         if: matrix.os == 'macos-latest'
         uses: melusina-org/gha-install-macports@v1.0.0
 
@@ -38,7 +38,7 @@ jobs:
         run: |
           sudo apt install tesseract
 
-      - name: Install tesseract(Linux)
+      - name: Install tesseract(Windows)
         if: matrix.os == 'windows-latest'
         run: |
           echo 'Not available'

--- a/.github/workflows/auto-test.yml
+++ b/.github/workflows/auto-test.yml
@@ -23,6 +23,25 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install hust_login
+
+      - name: Install MacPorts
+        if: matrix.os == 'macos-latest'
+        uses: melusina-org/gha-install-macports@v1.0.0
+
+      - name: Install tesseract(Mac)
+        if: matrix.os == 'macos-latest'
+        run: |
+          sudo port install tesseract
+
+      - name: Install tesseract(Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt install tesseract
+
+      - name: Install tesseract(Linux)
+        if: matrix.os == 'windows-latest'
+        run: |
+          echo 'Not available'
       
       - name: Test module
         run: |

--- a/.github/workflows/auto-test.yml
+++ b/.github/workflows/auto-test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install tesseract(Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt install tesseract
+          sudo apt install tesseract-ocr -y
 
       - name: Install tesseract(Windows)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/auto-test.yml
+++ b/.github/workflows/auto-test.yml
@@ -7,11 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Set up python
@@ -24,24 +20,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install hust_login
 
-      - name: Install MacPorts(Mac)
-        if: matrix.os == 'macos-latest'
-        uses: melusina-org/gha-install-macports@v1.0.0
-
-      - name: Install tesseract(Mac)
-        if: matrix.os == 'macos-latest'
-        run: |
-          sudo port install tesseract
-
-      - name: Install tesseract(Linux)
-        if: matrix.os == 'ubuntu-latest'
+      - name: Install tesseract
         run: |
           sudo apt install tesseract-ocr -y
-
-      - name: Install tesseract(Windows)
-        if: matrix.os == 'windows-latest'
-        run: |
-          echo 'Not available'
       
       - name: Test module
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest]
 
     needs: build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       
       - name: Test module
         run: |
-          python -m hust_login --autotest -U ${{ secrets.Uid }} -P ${{ secrets.Pwd }}
+          python -m hust_login --autotest -U ${{ secrets.UID }} -P ${{ secrets.PWD }}
           
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,33 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Install dependencies(Unix-like)
+      - name: Install MacPorts(Mac)
+        if: matrix.os == 'macos-latest'
+        uses: melusina-org/gha-install-macports@v1.0.0
+
+      - name: Install tesseract(Mac)
+        if: matrix.os == 'macos-latest'
+        run: |
+          sudo port install tesseract
+
+      - name: Install tesseract(Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt install tesseract
+
+      - name: Install tesseract(Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          echo 'Not available'
+
+      - name: Install artifact(Unix-like)
         if: matrix.os != 'windows-latest'
         run: |
           python -m pip install --upgrade pip
           cd artifact
           pip install hust_login-*.whl
           
-      - name: Install dependencies(WinNT-like)
+      - name: Install artifact(WinNT-like)
         if: matrix.os == 'windows-latest'
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install tesseract(Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt install tesseract
+          sudo apt install tesseract-ocr -y
 
       - name: Install tesseract(Windows)
         if: matrix.os == 'windows-latest'

--- a/hust_login/__main__.py
+++ b/hust_login/__main__.py
@@ -85,4 +85,4 @@ def main():
         print(_tasker(HUSTpass, conf['Tasks']))
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())


### PR DESCRIPTION
If you've ever looked at the action log, you'll see "USAGE: python -m hust_pass <option>" instead of success.
More importantly, tesseract is not installed, and you have not set Uid and Pwd in secrets, which makes automatic checking a joke.
Since there seems to be no effective way to install tesseract through cli under windows, the automatic test on windows will always fail, you can find a way by yourself or delete 'windows-latest' in the matrix.os .

In summary, if you want automatic checking to work properly, you need to set Uid and Pwd in secrets.