### PR TITLE
Follow upstream to SETUP-MACPORTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install MacPorts(Mac)
         if: matrix.os == 'macos-latest'
-        uses: melusina-org/gha-install-macports@v1.0.0
+        uses: melusina-org/setup-macports@v1
 
       - name: Install tesseract(Mac)
         if: matrix.os == 'macos-latest'


### PR DESCRIPTION
I'm about to archive gha-install-macports and continue work in setup-macports, so you might want to use that as well.